### PR TITLE
fix: resolve TypeScript compilation errors and deployment configuration

### DIFF
--- a/apps/api/src/agents/base.agent.ts
+++ b/apps/api/src/agents/base.agent.ts
@@ -1,7 +1,7 @@
 import { tool, type CoreTool } from "ai";
 import { z } from "zod";
 import type { AgentTool, AgentCapabilities } from "../types/index.js";
-import type { AgentType } from "@repo/database";
+import type { AgentType } from "@repo/shared-types";
 import { createServiceLogger } from "../lib/logger.js";
 
 const logger = createServiceLogger("agent-base");

--- a/apps/api/src/controllers/agents.controller.ts
+++ b/apps/api/src/controllers/agents.controller.ts
@@ -1,6 +1,6 @@
 /// <reference types="undici-types" />
 import type { Context } from "hono";
-import type { AgentType } from "@repo/database";
+import type { AgentType } from "@repo/shared-types";
 import { agentService } from "../services/agent.service.js";
 import { successResponse } from "../utils/response.js";
 import { NotFoundError } from "../lib/errors.js";

--- a/apps/api/src/services/stream.service.ts
+++ b/apps/api/src/services/stream.service.ts
@@ -1,6 +1,7 @@
 import { streamText, type CoreMessage, type CoreTool } from "ai";
 import { createGroq } from "@ai-sdk/groq";
-import { prisma, type AgentType } from "@repo/database";
+import { prisma } from "@repo/database";
+import type { AgentType } from "@repo/shared-types";
 import type { ToolCallResult } from "../types/index.js";
 import { createServiceLogger } from "../lib/logger.js";
 import { AIServiceError } from "../lib/errors.js";

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -23,6 +23,7 @@
     "devDependencies": {
         "@repo/typescript-config": "workspace:*",
         "@types/node": "^22.19.7",
+        "undici-types": "^6.20.0",
         "typescript": "^5.7.0"
     }
 }

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,16 +1,9 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "./base.json",
+    "extends": "@repo/typescript-config/node.json",
     "compilerOptions": {
-        "lib": [
-            "ES2022"
-        ],
-        "module": "NodeNext",
-        "moduleResolution": "NodeNext",
         "outDir": "dist",
         "rootDir": "src",
-        "declaration": true,
-        "declarationMap": true,
         "noEmit": false
     },
     "include": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@repo/database':
         specifier: workspace:*
         version: link:../../packages/database
+      '@repo/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       '@upstash/ratelimit':
         specifier: ^2.0.0
         version: 2.0.8(@upstash/redis@1.36.1)
@@ -84,6 +87,9 @@ importers:
       '@repo/api':
         specifier: workspace:*
         version: link:../api
+      '@repo/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -173,6 +179,25 @@ importers:
       eslint-plugin-import:
         specifier: ^2.29.0
         version: 2.32.0(@typescript-eslint/parser@8.53.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1)
+
+  packages/shared-types:
+    dependencies:
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
+    devDependencies:
+      '@repo/typescript-config':
+        specifier: workspace:*
+        version: link:../typescript-config
+      '@types/node':
+        specifier: ^22.19.7
+        version: 22.19.7
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+      undici-types:
+        specifier: ^6.20.0
+        version: 6.21.0
 
   packages/typescript-config: {}
 


### PR DESCRIPTION
- Fix shared-types tsconfig to extend from @repo/typescript-config/node.json
- Add undici-types to shared-types devDependencies for proper type definitions
- Fix AgentType imports to use @repo/shared-types instead of @repo/database
- Update API files to import from correct package
- Ensure Vercel deployment configuration works correctly with fixed builds