### PR TITLE
fix(api): forward x-request-id from Hono to AIML service

### DIFF
--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -41,10 +41,11 @@
     "@repo/eslint-config": "workspace:*",
     "@repo/typescript-config": "workspace:*",
     "@types/node": "^22.0.0",
-    "undici-types": "^6.20.0",
+    "@vitest/coverage-v8": "^2.1.9",
     "pino-pretty": "^13.1.3",
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
+    "undici-types": "^6.20.0",
     "vitest": "^2.1.0"
   }
 }

--- a/apps/api/src/__tests__/routes/agent.routes.test.ts
+++ b/apps/api/src/__tests__/routes/agent.routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
 
 import { agentRoutes } from "../../routes/agent.routes.js";
+import * as aimlClient from "../../services/aiml.client.js";
 
 function makeApp() {
   const app = new Hono();
@@ -125,6 +126,127 @@ describe("agent.routes proxy", () => {
     expect(calledUrl).toBe("http://aiml.test/v1/conversations");
     const headers = (init as RequestInit).headers as Headers;
     expect(headers.get("Authorization")).toBe("Bearer test-token");
+  });
+
+  it("/api/agent/run rejects invalid JSON with 400", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/agent/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+    expect((await res.json()).error.code).toBe("validation_failed");
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("/api/agent/run returns 502 when upstream body is missing", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 200, headers: { "content-type": "text/event-stream" } }),
+    );
+    const app = makeApp();
+    const res = await app.request("/api/agent/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "hi" }),
+    });
+    expect(res.status).toBe(502);
+    expect((await res.json()).error.code).toBe("upstream_error");
+  });
+
+  it("POST /api/agent/conversations propagates upstream error envelope", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: { code: "missing_scope", message: "needs aiml:write" } }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const app = makeApp();
+    const res = await app.request("/api/agent/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ title: "x" }),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("missing_scope");
+  });
+
+  it("GET /api/agent/conversations/:id propagates 404", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: { code: "not_found", message: "no such convo" } }),
+        { status: 404, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const app = makeApp();
+    const res = await app.request("/api/agent/conversations/missing-id");
+    expect(res.status).toBe(404);
+    expect((await res.json()).error.code).toBe("not_found");
+  });
+
+  it("/api/agent/run maps a non-AimlServiceError thrown by the client to 502", async () => {
+    const spy = vi.spyOn(aimlClient, "agentRun").mockRejectedValue(new Error("kaboom"));
+    const app = makeApp();
+    const res = await app.request("/api/agent/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "x" }),
+    });
+    expect(res.status).toBe(502);
+    expect((await res.json()).error.message).toBe("kaboom");
+    spy.mockRestore();
+  });
+
+  it("POST /api/agent/conversations maps non-AimlServiceError to 502", async () => {
+    const spy = vi.spyOn(aimlClient, "createConversation").mockRejectedValue(new Error("no convo"));
+    const app = makeApp();
+    const res = await app.request("/api/agent/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    expect(res.status).toBe(502);
+    expect((await res.json()).error.message).toBe("no convo");
+    spy.mockRestore();
+  });
+
+  it("GET /api/agent/conversations/:id maps non-AimlServiceError to 502", async () => {
+    const spy = vi.spyOn(aimlClient, "getConversation").mockRejectedValue(new Error("no get"));
+    const app = makeApp();
+    const res = await app.request("/api/agent/conversations/abc");
+    expect(res.status).toBe(502);
+    expect((await res.json()).error.message).toBe("no get");
+    spy.mockRestore();
+  });
+
+  it("POST /api/agent/conversations accepts an empty body (catch path)", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ id: "c-empty", title: null, createdAt: "2026-05-08T00:00:00Z" }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const app = makeApp();
+    const res = await app.request("/api/agent/conversations", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(200);
+    expect((await res.json()).id).toBe("c-empty");
+  });
+
+  it("/api/agent/run returns 502 + rid when fetch rejects (network error)", async () => {
+    fetchSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+    const app = makeApp();
+    const res = await app.request("/api/agent/run", {
+      method: "POST",
+      headers: { "x-request-id": "net-7", "Content-Type": "application/json" },
+      body: JSON.stringify({ message: "x" }),
+    });
+    expect(res.status).toBe(502);
+    expect(res.headers.get("x-request-id")).toBe("net-7");
+    expect((await res.json()).error.code).toBe("upstream_error");
   });
 
   it("forwards inbound x-request-id to /v1/agents/run and echoes it back", async () => {

--- a/apps/api/src/__tests__/routes/agent.routes.test.ts
+++ b/apps/api/src/__tests__/routes/agent.routes.test.ts
@@ -127,6 +127,33 @@ describe("agent.routes proxy", () => {
     expect(headers.get("Authorization")).toBe("Bearer test-token");
   });
 
+  it("forwards inbound x-request-id to /v1/agents/run and echoes it back", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response("event: done\ndata: {}\n\n", {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      }),
+    );
+
+    const app = makeApp();
+    const inboundRid = "agent-rid-42";
+    const res = await app.request("/api/agent/run", {
+      method: "POST",
+      headers: {
+        "x-request-id": inboundRid,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ message: "hi" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-request-id")).toBe(inboundRid);
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Headers;
+    expect(headers.get("x-request-id")).toBe(inboundRid);
+  });
+
   it("fetches a conversation by id", async () => {
     fetchSpy.mockResolvedValueOnce(
       new Response(

--- a/apps/api/src/__tests__/routes/rag.routes.test.ts
+++ b/apps/api/src/__tests__/routes/rag.routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
 
 import { ragRoutes } from "../../routes/rag.routes.js";
+import * as aimlClient from "../../services/aiml.client.js";
 
 function makeApp() {
   const app = new Hono();
@@ -109,6 +110,177 @@ describe("rag.routes proxy", () => {
     });
     expect(res.status).toBe(200);
     expect(fetchSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it("/api/rag/query returns 502 when upstream body is missing", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(null, { status: 200, headers: { "content-type": "text/event-stream" } }),
+    );
+    const app = makeApp();
+    const res = await app.request("/api/rag/query", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "hi" }),
+    });
+    expect(res.status).toBe(502);
+    expect(res.headers.get("x-request-id")).toBeTruthy();
+    const body = await res.json();
+    expect(body.error.code).toBe("upstream_error");
+    expect(body.error.requestId).toBe(res.headers.get("x-request-id"));
+  });
+
+  it("/api/rag/query rejects invalid JSON body with 400", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/rag/query", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+    expect(await res.json()).toMatchObject({
+      error: { code: "validation_failed" },
+    });
+  });
+
+  it("/api/rag/query propagates upstream AimlServiceError envelope", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({
+          error: { code: "missing_scope", message: "needs aiml:read", requestId: "rid-up" },
+        }),
+        { status: 403, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const app = makeApp();
+    const res = await app.request("/api/rag/query", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "hi" }),
+    });
+    expect(res.status).toBe(403);
+    expect((await res.json()).error.code).toBe("missing_scope");
+  });
+
+  it("/api/rag/query rejects empty query string with 400", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/rag/query", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  it("/api/rag/document/analyze proxies multipart and propagates errors", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ text: "hello", pages: [], tables: [], key_value_pairs: [] }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const app = makeApp();
+    const res = await app.request("/api/rag/document/analyze", {
+      method: "POST",
+      headers: { "Content-Type": "application/pdf", "x-request-id": "doc-1" },
+      body: new Uint8Array([0x25, 0x50, 0x44, 0x46]),
+    });
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-request-id")).toBe("doc-1");
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Headers;
+    expect(headers.get("Content-Type")).toBe("application/pdf");
+    expect(headers.get("x-request-id")).toBe("doc-1");
+  });
+
+  it("/api/rag/document/analyze surfaces upstream 4xx envelope", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(
+        JSON.stringify({ error: { code: "payload_too_large", message: "too big" } }),
+        { status: 413, headers: { "content-type": "application/json" } },
+      ),
+    );
+    const app = makeApp();
+    const res = await app.request("/api/rag/document/analyze", {
+      method: "POST",
+      headers: { "Content-Type": "application/pdf" },
+      body: new Uint8Array([0]),
+    });
+    expect(res.status).toBe(413);
+    expect((await res.json()).error.code).toBe("payload_too_large");
+  });
+
+  it("/api/rag/ingest rejects invalid JSON with 400 + rid", async () => {
+    const app = makeApp();
+    const res = await app.request("/api/rag/ingest", {
+      method: "POST",
+      headers: { "x-request-id": "ingest-bad-json", "Content-Type": "application/json" },
+      body: "not-json",
+    });
+    expect(res.status).toBe(400);
+    expect(res.headers.get("x-request-id")).toBe("ingest-bad-json");
+    expect((await res.json()).error.code).toBe("validation_failed");
+  });
+
+  it("/api/rag/query maps a non-AimlServiceError thrown by the client to 502", async () => {
+    // Defense-in-depth branch: client today only throws AimlServiceError, but
+    // the route still has a generic Error fallback. Force-cover it by mocking
+    // ragQuery to throw a plain Error.
+    const spy = vi.spyOn(aimlClient, "ragQuery").mockRejectedValue(new Error("kaboom"));
+    const app = makeApp();
+    const res = await app.request("/api/rag/query", {
+      method: "POST",
+      headers: { "x-request-id": "boom-1", "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "x" }),
+    });
+    expect(res.status).toBe(502);
+    expect(res.headers.get("x-request-id")).toBe("boom-1");
+    const body = await res.json();
+    expect(body.error.code).toBe("upstream_error");
+    expect(body.error.message).toBe("kaboom");
+    spy.mockRestore();
+  });
+
+  it("/api/rag/ingest maps a non-AimlServiceError to 502 envelope", async () => {
+    const spy = vi.spyOn(aimlClient, "ragIngest").mockRejectedValue(new Error("ingest blew up"));
+    const app = makeApp();
+    const res = await app.request("/api/rag/ingest", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ documents: [{ id: "d", text: "t", metadata: {} }] }),
+    });
+    expect(res.status).toBe(502);
+    expect((await res.json()).error.message).toBe("ingest blew up");
+    spy.mockRestore();
+  });
+
+  it("/api/rag/document/analyze maps a non-AimlServiceError to 502 envelope", async () => {
+    const spy = vi.spyOn(aimlClient, "documentAnalyze").mockRejectedValue(new Error("doc blew up"));
+    const app = makeApp();
+    const res = await app.request("/api/rag/document/analyze", {
+      method: "POST",
+      headers: { "Content-Type": "application/pdf" },
+      body: new Uint8Array([0]),
+    });
+    expect(res.status).toBe(502);
+    expect((await res.json()).error.message).toBe("doc blew up");
+    spy.mockRestore();
+  });
+
+  it("/api/rag/query returns 502 with rid when fetch itself rejects", async () => {
+    // Make every retry attempt reject — the client should ultimately surface
+    // an AimlServiceError, which the route maps back to the upstream_error
+    // envelope via the AimlServiceError branch (not the generic catch).
+    fetchSpy.mockRejectedValue(new Error("ECONNREFUSED"));
+    const app = makeApp();
+    const res = await app.request("/api/rag/query", {
+      method: "POST",
+      headers: { "x-request-id": "net-1", "Content-Type": "application/json" },
+      body: JSON.stringify({ query: "x" }),
+    });
+    expect(res.status).toBe(502);
+    expect(res.headers.get("x-request-id")).toBe("net-1");
+    expect((await res.json()).error.code).toBe("upstream_error");
   });
 
   it("forwards inbound x-request-id verbatim and echoes it on the response", async () => {

--- a/apps/api/src/__tests__/routes/rag.routes.test.ts
+++ b/apps/api/src/__tests__/routes/rag.routes.test.ts
@@ -111,6 +111,59 @@ describe("rag.routes proxy", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(2);
   });
 
+  it("forwards inbound x-request-id verbatim and echoes it on the response", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ingested: 1, nodes: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const app = makeApp();
+    const inboundRid = "req-abc-123";
+    const res = await app.request("/api/rag/ingest", {
+      method: "POST",
+      headers: {
+        "x-request-id": inboundRid,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ documents: [{ id: "d", text: "t", metadata: {} }] }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("x-request-id")).toBe(inboundRid);
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Headers;
+    expect(headers.get("x-request-id")).toBe(inboundRid);
+  });
+
+  it("generates a fresh x-request-id when caller omits the header", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ingested: 1, nodes: 1 }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+    const app = makeApp();
+    const res = await app.request("/api/rag/ingest", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ documents: [{ id: "d", text: "t", metadata: {} }] }),
+    });
+
+    expect(res.status).toBe(200);
+    const echoed = res.headers.get("x-request-id");
+    expect(echoed).toBeTruthy();
+    // UUIDv4 shape
+    expect(echoed).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/);
+
+    const init = fetchSpy.mock.calls[0][1] as RequestInit;
+    const headers = init.headers as Headers;
+    expect(headers.get("x-request-id")).toBe(echoed);
+  });
+
   it("/api/rag/query passes through SSE body and forwards auth", async () => {
     const sse = "event: token\ndata: {\"delta\":\"hi\"}\n\nevent: done\ndata: {\"answer\":\"hi\"}\n\n";
     fetchSpy.mockResolvedValueOnce(

--- a/apps/api/src/routes/agent.routes.ts
+++ b/apps/api/src/routes/agent.routes.ts
@@ -3,6 +3,10 @@
  *
  * Mounted under /api/agent (singular) — the existing /api/agents (plural)
  * is reserved for the legacy multi-agent classifier flow in agents.routes.ts.
+ *
+ * Each handler computes a stable x-request-id (inbound or freshly generated)
+ * and forwards it to the AIML service so logs from both services share the
+ * same correlation id. The id is also echoed back on the Hono response.
  */
 import { Hono } from "hono";
 
@@ -16,29 +20,39 @@ import {
 
 const agentRoutes = new Hono();
 
-function authHeader(c: { req: { header: (name: string) => string | undefined } }): string | undefined {
+type HonoCtx = { req: { header: (name: string) => string | undefined } };
+
+function authHeader(c: HonoCtx): string | undefined {
   return c.req.header("authorization") ?? c.req.header("Authorization");
 }
 
-function envelope(code: string, message: string, requestId?: string) {
-  return { error: { code, message, requestId } };
+function requestId(c: HonoCtx): string {
+  return c.req.header("x-request-id") ?? c.req.header("X-Request-Id") ?? crypto.randomUUID();
+}
+
+function envelope(code: string, message: string, rid?: string) {
+  return { error: { code, message, requestId: rid } };
 }
 
 agentRoutes.post("/run", async (c) => {
+  const rid = requestId(c);
   let body: AgentRunBody;
   try {
     body = (await c.req.json()) as AgentRunBody;
   } catch {
-    return c.json(envelope("validation_failed", "invalid JSON body"), 400);
+    c.header("x-request-id", rid);
+    return c.json(envelope("validation_failed", "invalid JSON body", rid), 400);
   }
   if (!body?.message || typeof body.message !== "string") {
-    return c.json(envelope("validation_failed", "message must be a non-empty string"), 400);
+    c.header("x-request-id", rid);
+    return c.json(envelope("validation_failed", "message must be a non-empty string", rid), 400);
   }
 
   try {
-    const upstream = await agentRun(body, { authorization: authHeader(c) });
+    const upstream = await agentRun(body, { authorization: authHeader(c), requestId: rid });
     if (!upstream.body) {
-      return c.json(envelope("upstream_error", "empty stream from aiml service"), 502);
+      c.header("x-request-id", rid);
+      return c.json(envelope("upstream_error", "empty stream from aiml service", rid), 502);
     }
     return new Response(upstream.body, {
       status: upstream.status,
@@ -46,20 +60,24 @@ agentRoutes.post("/run", async (c) => {
         "Content-Type": upstream.headers.get("content-type") ?? "text/event-stream",
         "Cache-Control": "no-cache",
         "X-Accel-Buffering": "no",
+        "x-request-id": rid,
       },
     });
   } catch (err) {
+    c.header("x-request-id", rid);
     if (err instanceof AimlServiceError) {
-      return c.json(envelope(err.code, err.message, err.requestId), err.status as 400);
+      return c.json(envelope(err.code, err.message, err.requestId ?? rid), err.status as 400);
     }
     return c.json(
-      envelope("upstream_error", err instanceof Error ? err.message : "unknown"),
+      envelope("upstream_error", err instanceof Error ? err.message : "unknown", rid),
       502,
     );
   }
 });
 
 agentRoutes.post("/conversations", async (c) => {
+  const rid = requestId(c);
+  c.header("x-request-id", rid);
   let body: { title?: string; metadata?: Record<string, unknown> } = {};
   try {
     body = (await c.req.json()) as typeof body;
@@ -67,30 +85,38 @@ agentRoutes.post("/conversations", async (c) => {
     // Empty body is OK — the AIML service accepts it.
   }
   try {
-    const created = await createConversation(body, { authorization: authHeader(c) });
+    const created = await createConversation(body, {
+      authorization: authHeader(c),
+      requestId: rid,
+    });
     return c.json(created);
   } catch (err) {
     if (err instanceof AimlServiceError) {
-      return c.json(envelope(err.code, err.message, err.requestId), err.status as 400);
+      return c.json(envelope(err.code, err.message, err.requestId ?? rid), err.status as 400);
     }
     return c.json(
-      envelope("upstream_error", err instanceof Error ? err.message : "unknown"),
+      envelope("upstream_error", err instanceof Error ? err.message : "unknown", rid),
       502,
     );
   }
 });
 
 agentRoutes.get("/conversations/:id", async (c) => {
+  const rid = requestId(c);
+  c.header("x-request-id", rid);
   const id = c.req.param("id");
   try {
-    const convo = await getConversation(id, { authorization: authHeader(c) });
+    const convo = await getConversation(id, {
+      authorization: authHeader(c),
+      requestId: rid,
+    });
     return c.json(convo);
   } catch (err) {
     if (err instanceof AimlServiceError) {
-      return c.json(envelope(err.code, err.message, err.requestId), err.status as 400);
+      return c.json(envelope(err.code, err.message, err.requestId ?? rid), err.status as 400);
     }
     return c.json(
-      envelope("upstream_error", err instanceof Error ? err.message : "unknown"),
+      envelope("upstream_error", err instanceof Error ? err.message : "unknown", rid),
       502,
     );
   }

--- a/apps/api/src/routes/rag.routes.ts
+++ b/apps/api/src/routes/rag.routes.ts
@@ -11,28 +11,46 @@ import {
 
 const ragRoutes = new Hono();
 
-function authHeader(c: { req: { header: (name: string) => string | undefined } }): string | undefined {
+type HonoCtx = { req: { header: (name: string) => string | undefined } };
+
+function authHeader(c: HonoCtx): string | undefined {
   return c.req.header("authorization") ?? c.req.header("Authorization");
 }
 
-function envelope(code: string, message: string, requestId?: string) {
-  return { error: { code, message, requestId } };
+/**
+ * Read inbound x-request-id; if absent, generate a fresh UUIDv4 so the
+ * Python service still sees a stable id and the same id can be echoed
+ * to our caller for log correlation.
+ */
+function requestId(c: HonoCtx): string {
+  return c.req.header("x-request-id") ?? c.req.header("X-Request-Id") ?? crypto.randomUUID();
+}
+
+function envelope(code: string, message: string, rid?: string) {
+  return { error: { code, message, requestId: rid } };
 }
 
 ragRoutes.post("/query", async (c) => {
+  const rid = requestId(c);
   let body: RagQueryBody;
   try {
     body = (await c.req.json()) as RagQueryBody;
   } catch {
-    return c.json(envelope("validation_failed", "invalid JSON body"), 400);
+    c.header("x-request-id", rid);
+    return c.json(envelope("validation_failed", "invalid JSON body", rid), 400);
   }
   if (!body?.query || typeof body.query !== "string") {
-    return c.json(envelope("validation_failed", "query must be a non-empty string"), 400);
+    c.header("x-request-id", rid);
+    return c.json(envelope("validation_failed", "query must be a non-empty string", rid), 400);
   }
   try {
-    const upstream = await ragQuery(body, { authorization: authHeader(c) });
+    const upstream = await ragQuery(body, {
+      authorization: authHeader(c),
+      requestId: rid,
+    });
     if (!upstream.body) {
-      return c.json(envelope("upstream_error", "empty stream from aiml service"), 502);
+      c.header("x-request-id", rid);
+      return c.json(envelope("upstream_error", "empty stream from aiml service", rid), 502);
     }
     return new Response(upstream.body, {
       status: upstream.status,
@@ -40,58 +58,68 @@ ragRoutes.post("/query", async (c) => {
         "Content-Type": upstream.headers.get("content-type") ?? "text/event-stream",
         "Cache-Control": "no-cache",
         "X-Accel-Buffering": "no",
+        "x-request-id": rid,
       },
     });
   } catch (err) {
+    c.header("x-request-id", rid);
     if (err instanceof AimlServiceError) {
-      return c.json(envelope(err.code, err.message, err.requestId), err.status as 400);
+      return c.json(envelope(err.code, err.message, err.requestId ?? rid), err.status as 400);
     }
     return c.json(
-      envelope("upstream_error", err instanceof Error ? err.message : "unknown"),
+      envelope("upstream_error", err instanceof Error ? err.message : "unknown", rid),
       502,
     );
   }
 });
 
 ragRoutes.post("/ingest", async (c) => {
+  const rid = requestId(c);
+  c.header("x-request-id", rid);
   let body: RagIngestBody;
   try {
     body = (await c.req.json()) as RagIngestBody;
   } catch {
-    return c.json(envelope("validation_failed", "invalid JSON body"), 400);
+    return c.json(envelope("validation_failed", "invalid JSON body", rid), 400);
   }
   if (!Array.isArray(body?.documents) || body.documents.length === 0) {
-    return c.json(envelope("validation_failed", "documents must be a non-empty array"), 400);
+    return c.json(envelope("validation_failed", "documents must be a non-empty array", rid), 400);
   }
   try {
-    const result = await ragIngest(body, { authorization: authHeader(c) });
+    const result = await ragIngest(body, {
+      authorization: authHeader(c),
+      requestId: rid,
+    });
     return c.json(result);
   } catch (err) {
     if (err instanceof AimlServiceError) {
-      return c.json(envelope(err.code, err.message, err.requestId), err.status as 400);
+      return c.json(envelope(err.code, err.message, err.requestId ?? rid), err.status as 400);
     }
     return c.json(
-      envelope("upstream_error", err instanceof Error ? err.message : "unknown"),
+      envelope("upstream_error", err instanceof Error ? err.message : "unknown", rid),
       502,
     );
   }
 });
 
 ragRoutes.post("/document/analyze", async (c) => {
+  const rid = requestId(c);
+  c.header("x-request-id", rid);
   const contentType = c.req.header("content-type") ?? "application/octet-stream";
   const buf = await c.req.arrayBuffer();
   try {
     const upstream = await documentAnalyze(buf, contentType, {
       authorization: authHeader(c),
+      requestId: rid,
     });
     const data = await upstream.json();
     return c.json(data);
   } catch (err) {
     if (err instanceof AimlServiceError) {
-      return c.json(envelope(err.code, err.message, err.requestId), err.status as 400);
+      return c.json(envelope(err.code, err.message, err.requestId ?? rid), err.status as 400);
     }
     return c.json(
-      envelope("upstream_error", err instanceof Error ? err.message : "unknown"),
+      envelope("upstream_error", err instanceof Error ? err.message : "unknown", rid),
       502,
     );
   }

--- a/apps/api/src/services/aiml.client.ts
+++ b/apps/api/src/services/aiml.client.ts
@@ -15,6 +15,11 @@ const RETRY_DELAYS_MS = [200, 600, 1800];
 export interface AimlClientOptions {
   baseUrl?: string;
   authorization?: string | null;
+  /**
+   * Request id to forward to the AIML service so logs from both services
+   * can be correlated end-to-end. Forwarded as the `x-request-id` header.
+   */
+  requestId?: string | null;
   timeoutMs?: number;
 }
 
@@ -39,6 +44,9 @@ function buildHeaders(opts: AimlClientOptions | undefined, extra: Record<string,
   const headers = new Headers(extra);
   if (opts?.authorization) {
     headers.set("Authorization", opts.authorization);
+  }
+  if (opts?.requestId) {
+    headers.set("x-request-id", opts.requestId);
   }
   return headers;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       '@types/node':
         specifier: ^22.0.0
         version: 22.19.7
+      '@vitest/coverage-v8':
+        specifier: ^2.1.9
+        version: 2.1.9(vitest@2.1.9(@types/node@22.19.7))
       pino-pretty:
         specifier: ^13.1.3
         version: 13.1.3
@@ -144,7 +147,7 @@ importers:
     dependencies:
       '@prisma/client':
         specifier: ^6.2.0
-        version: 6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)
+        version: 6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)
     devDependencies:
       '@repo/typescript-config':
         specifier: workspace:*
@@ -154,7 +157,7 @@ importers:
         version: 22.19.7
       prisma:
         specifier: ^6.2.0
-        version: 6.19.2(typescript@5.9.3)
+        version: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
       tsx:
         specifier: ^4.19.0
         version: 4.21.0
@@ -238,6 +241,30 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@ampproject/remapping@2.3.0':
+    resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
+    engines: {node: '>=6.0.0'}
+
+  '@babel/helper-string-parser@7.27.1':
+    resolution: {integrity: sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/parser@7.29.3':
+    resolution: {integrity: sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
+    engines: {node: '>=6.9.0'}
+
+  '@bcoe/v8-coverage@0.2.3':
+    resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
   '@emnapi/runtime@1.8.1':
     resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
@@ -716,6 +743,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/cliui@8.0.2':
+    resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
+    engines: {node: '>=12'}
+
+  '@istanbuljs/schema@0.1.6':
+    resolution: {integrity: sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==}
+    engines: {node: '>=8'}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -798,6 +833,10 @@ packages:
 
   '@pinojs/redact@0.4.0':
     resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@pkgjs/parseargs@0.11.0':
+    resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
+    engines: {node: '>=14'}
 
   '@prisma/client@6.19.2':
     resolution: {integrity: sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==}
@@ -1063,6 +1102,15 @@ packages:
   '@upstash/redis@1.36.1':
     resolution: {integrity: sha512-N6SjDcgXdOcTAF+7uNoY69o7hCspe9BcA7YjQdxVu5d25avljTwyLaHBW3krWjrP0FfocgMk94qyVtQbeDp39A==}
 
+  '@vitest/coverage-v8@2.1.9':
+    resolution: {integrity: sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==}
+    peerDependencies:
+      '@vitest/browser': 2.1.9
+      vitest: 2.1.9
+    peerDependenciesMeta:
+      '@vitest/browser':
+        optional: true
+
   '@vitest/expect@2.1.9':
     resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
 
@@ -1127,9 +1175,17 @@ packages:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
 
+  ansi-regex@6.2.2:
+    resolution: {integrity: sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==}
+    engines: {node: '>=12'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@6.2.3:
+    resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
+    engines: {node: '>=12'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -1197,6 +1253,10 @@ packages:
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
   baseline-browser-mapping@2.9.14:
     resolution: {integrity: sha512-B0xUquLkiGLgHhpPBqvl7GWegWBUNuujQ6kXd/r1U38ElPT6Ok8KZ8e+FpUGEc2ZoRQUzq/aUnaKFc/svWUGSg==}
     hasBin: true
@@ -1210,6 +1270,10 @@ packages:
 
   brace-expansion@2.0.2:
     resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1427,11 +1491,20 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  eastasianwidth@0.2.0:
+    resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
+
   effect@3.18.4:
     resolution: {integrity: sha512-b1LXQJLe9D11wfnOKAk3PKxuqYshQ0Heez+y5pnkd3jLj1yx9QhM72zZ9uUrOQyNvrs2GZZd/3maL0ZV18YuDA==}
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  emoji-regex@9.2.2:
+    resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
 
   empathic@2.0.0:
     resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
@@ -1639,6 +1712,10 @@ packages:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
 
+  foreground-child@3.3.1:
+    resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
+    engines: {node: '>=14'}
+
   form-data-encoder@1.7.2:
     resolution: {integrity: sha512-qfqtYan3rxrnCk1VYaA4H+Ms9xdpPqvLZa6xmMgFvhO32x7/3J/ExcTd6qpxM0vH2GdMI+poehyBZvqfMTto8A==}
 
@@ -1716,6 +1793,11 @@ packages:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
 
+  glob@10.5.0:
+    resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+    hasBin: true
+
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
@@ -1771,6 +1853,9 @@ packages:
   hono@4.11.4:
     resolution: {integrity: sha512-U7tt8JsyrxSRKspfhtLET79pU8K+tInj5QZXs1jSugO1Vq5dFj3kmZsRldo29mTBfcjDRVRXrEZ6LS63Cog9ZA==}
     engines: {node: '>=16.9.0'}
+
+  html-escaper@2.0.2:
+    resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
   humanize-ms@1.2.1:
     resolution: {integrity: sha512-Fl70vYtsAFb/C06PTS9dZBo7ihau+Tu/DNCk/OyHhea07S+aeMWpFFkUaXRa8fI+ScZbEI8dfSxwY7gxZ9SAVQ==}
@@ -1846,6 +1931,10 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -1916,6 +2005,25 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  istanbul-lib-coverage@3.2.2:
+    resolution: {integrity: sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==}
+    engines: {node: '>=8'}
+
+  istanbul-lib-report@3.0.1:
+    resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
+    engines: {node: '>=10'}
+
+  istanbul-lib-source-maps@5.0.6:
+    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
+    engines: {node: '>=10'}
+
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
+    engines: {node: '>=8'}
+
+  jackspeak@3.4.3:
+    resolution: {integrity: sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==}
+
   jiti@1.21.7:
     resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
     hasBin: true
@@ -1977,8 +2085,18 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  magicast@0.3.5:
+    resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  make-dir@4.0.0:
+    resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
+    engines: {node: '>=10'}
 
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
@@ -2000,6 +2118,10 @@ packages:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
 
@@ -2009,6 +2131,10 @@ packages:
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
 
   motion-dom@11.18.1:
     resolution: {integrity: sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==}
@@ -2143,6 +2269,9 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  package-json-from-dist@1.0.1:
+    resolution: {integrity: sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2161,6 +2290,10 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@1.11.1:
+    resolution: {integrity: sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==}
+    engines: {node: '>=16 || 14 >=14.18'}
 
   pathe@1.1.2:
     resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
@@ -2443,6 +2576,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   sonic-boom@4.2.0:
     resolution: {integrity: sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==}
 
@@ -2464,6 +2601,14 @@ packages:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
 
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  string-width@5.1.2:
+    resolution: {integrity: sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==}
+    engines: {node: '>=12'}
+
   string.prototype.trim@1.2.10:
     resolution: {integrity: sha512-Rs66F0P/1kedk5lyYyH9uBzuiI/kNRmwJAR9quK6VOtIpZ2G+hMZd+HQbbv25MgCA6gEffoMZYxlTod4WcdrKA==}
     engines: {node: '>= 0.4'}
@@ -2479,6 +2624,10 @@ packages:
   strip-ansi@6.0.1:
     resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
     engines: {node: '>=8'}
+
+  strip-ansi@7.2.0:
+    resolution: {integrity: sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==}
+    engines: {node: '>=12'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2527,6 +2676,10 @@ packages:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
     hasBin: true
+
+  test-exclude@7.0.2:
+    resolution: {integrity: sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==}
+    engines: {node: '>=18'}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -2792,6 +2945,14 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  wrap-ansi@8.1.0:
+    resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
+    engines: {node: '>=12'}
+
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
@@ -2862,6 +3023,26 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@ampproject/remapping@2.3.0':
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@babel/helper-string-parser@7.27.1': {}
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/parser@7.29.3':
+    dependencies:
+      '@babel/types': 7.29.0
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
+
+  '@bcoe/v8-coverage@0.2.3': {}
 
   '@emnapi/runtime@1.8.1':
     dependencies:
@@ -3156,6 +3337,17 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@isaacs/cliui@8.0.2':
+    dependencies:
+      string-width: 5.1.2
+      string-width-cjs: string-width@4.2.3
+      strip-ansi: 7.2.0
+      strip-ansi-cjs: strip-ansi@6.0.1
+      wrap-ansi: 8.1.0
+      wrap-ansi-cjs: wrap-ansi@7.0.0
+
+  '@istanbuljs/schema@0.1.6': {}
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3212,14 +3404,17 @@ snapshots:
 
   '@pinojs/redact@0.4.0': {}
 
-  '@prisma/client@6.19.2(prisma@6.19.2(typescript@5.9.3))(typescript@5.9.3)':
+  '@pkgjs/parseargs@0.11.0':
+    optional: true
+
+  '@prisma/client@6.19.2(prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
-      prisma: 6.19.2(typescript@5.9.3)
+      prisma: 6.19.2(magicast@0.3.5)(typescript@5.9.3)
       typescript: 5.9.3
 
-  '@prisma/config@6.19.2':
+  '@prisma/config@6.19.2(magicast@0.3.5)':
     dependencies:
-      c12: 3.1.0
+      c12: 3.1.0(magicast@0.3.5)
       deepmerge-ts: 7.1.5
       effect: 3.18.4
       empathic: 2.0.0
@@ -3463,6 +3658,24 @@ snapshots:
     dependencies:
       uncrypto: 0.1.3
 
+  '@vitest/coverage-v8@2.1.9(vitest@2.1.9(@types/node@22.19.7))':
+    dependencies:
+      '@ampproject/remapping': 2.3.0
+      '@bcoe/v8-coverage': 0.2.3
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+      istanbul-lib-report: 3.0.1
+      istanbul-lib-source-maps: 5.0.6
+      istanbul-reports: 3.2.0
+      magic-string: 0.30.21
+      magicast: 0.3.5
+      std-env: 3.10.0
+      test-exclude: 7.0.2
+      tinyrainbow: 1.2.0
+      vitest: 2.1.9(@types/node@22.19.7)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/expect@2.1.9':
     dependencies:
       '@vitest/spy': 2.1.9
@@ -3538,9 +3751,13 @@ snapshots:
 
   ansi-regex@5.0.1: {}
 
+  ansi-regex@6.2.2: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@6.2.3: {}
 
   any-promise@1.3.0: {}
 
@@ -3626,6 +3843,8 @@ snapshots:
 
   balanced-match@1.0.2: {}
 
+  balanced-match@4.0.4: {}
+
   baseline-browser-mapping@2.9.14: {}
 
   binary-extensions@2.3.0: {}
@@ -3639,6 +3858,10 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
 
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
+
   braces@3.0.3:
     dependencies:
       fill-range: 7.1.1
@@ -3651,7 +3874,7 @@ snapshots:
       node-releases: 2.0.27
       update-browserslist-db: 1.2.3(browserslist@4.28.1)
 
-  c12@3.1.0:
+  c12@3.1.0(magicast@0.3.5):
     dependencies:
       chokidar: 4.0.3
       confbox: 0.2.2
@@ -3665,6 +3888,8 @@ snapshots:
       perfect-debounce: 1.0.0
       pkg-types: 2.3.0
       rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.3.5
 
   cac@6.7.14: {}
 
@@ -3843,12 +4068,18 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  eastasianwidth@0.2.0: {}
+
   effect@3.18.4:
     dependencies:
       '@standard-schema/spec': 1.1.0
       fast-check: 3.23.2
 
   electron-to-chromium@1.5.267: {}
+
+  emoji-regex@8.0.0: {}
+
+  emoji-regex@9.2.2: {}
 
   empathic@2.0.0: {}
 
@@ -4185,6 +4416,11 @@ snapshots:
     dependencies:
       is-callable: 1.2.7
 
+  foreground-child@3.3.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      signal-exit: 4.1.0
+
   form-data-encoder@1.7.2: {}
 
   form-data@4.0.5:
@@ -4276,6 +4512,15 @@ snapshots:
     dependencies:
       is-glob: 4.0.3
 
+  glob@10.5.0:
+    dependencies:
+      foreground-child: 3.3.1
+      jackspeak: 3.4.3
+      minimatch: 9.0.5
+      minipass: 7.1.3
+      package-json-from-dist: 1.0.1
+      path-scurry: 1.11.1
+
   glob@7.2.3:
     dependencies:
       fs.realpath: 1.0.0
@@ -4335,6 +4580,8 @@ snapshots:
   help-me@5.0.0: {}
 
   hono@4.11.4: {}
+
+  html-escaper@2.0.2: {}
 
   humanize-ms@1.2.1:
     dependencies:
@@ -4414,6 +4661,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -4482,6 +4731,33 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  istanbul-lib-coverage@3.2.2: {}
+
+  istanbul-lib-report@3.0.1:
+    dependencies:
+      istanbul-lib-coverage: 3.2.2
+      make-dir: 4.0.0
+      supports-color: 7.2.0
+
+  istanbul-lib-source-maps@5.0.6:
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.31
+      debug: 4.4.3
+      istanbul-lib-coverage: 3.2.2
+    transitivePeerDependencies:
+      - supports-color
+
+  istanbul-reports@3.2.0:
+    dependencies:
+      html-escaper: 2.0.2
+      istanbul-lib-report: 3.0.1
+
+  jackspeak@3.4.3:
+    dependencies:
+      '@isaacs/cliui': 8.0.2
+    optionalDependencies:
+      '@pkgjs/parseargs': 0.11.0
+
   jiti@1.21.7: {}
 
   jiti@2.6.1: {}
@@ -4531,9 +4807,21 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@10.4.3: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  magicast@0.3.5:
+    dependencies:
+      '@babel/parser': 7.29.3
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
+  make-dir@4.0.0:
+    dependencies:
+      semver: 7.7.3
 
   math-intrinsics@1.1.0: {}
 
@@ -4550,6 +4838,10 @@ snapshots:
     dependencies:
       mime-db: 1.52.0
 
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
@@ -4559,6 +4851,8 @@ snapshots:
       brace-expansion: 2.0.2
 
   minimist@1.2.8: {}
+
+  minipass@7.1.3: {}
 
   motion-dom@11.18.1:
     dependencies:
@@ -4692,6 +4986,8 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  package-json-from-dist@1.0.1: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -4703,6 +4999,11 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-scurry@1.11.1:
+    dependencies:
+      lru-cache: 10.4.3
+      minipass: 7.1.3
 
   pathe@1.1.2: {}
 
@@ -4816,9 +5117,9 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prisma@6.19.2(typescript@5.9.3):
+  prisma@6.19.2(magicast@0.3.5)(typescript@5.9.3):
     dependencies:
-      '@prisma/config': 6.19.2
+      '@prisma/config': 6.19.2(magicast@0.3.5)
       '@prisma/engines': 6.19.2
     optionalDependencies:
       typescript: 5.9.3
@@ -5056,6 +5357,8 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@4.1.0: {}
+
   sonic-boom@4.2.0:
     dependencies:
       atomic-sleep: 1.0.0
@@ -5072,6 +5375,18 @@ snapshots:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  string-width@5.1.2:
+    dependencies:
+      eastasianwidth: 0.2.0
+      emoji-regex: 9.2.2
+      strip-ansi: 7.2.0
 
   string.prototype.trim@1.2.10:
     dependencies:
@@ -5099,6 +5414,10 @@ snapshots:
   strip-ansi@6.0.1:
     dependencies:
       ansi-regex: 5.0.1
+
+  strip-ansi@7.2.0:
+    dependencies:
+      ansi-regex: 6.2.2
 
   strip-bom@3.0.0: {}
 
@@ -5160,6 +5479,12 @@ snapshots:
     transitivePeerDependencies:
       - tsx
       - yaml
+
+  test-exclude@7.0.2:
+    dependencies:
+      '@istanbuljs/schema': 0.1.6
+      glob: 10.5.0
+      minimatch: 10.2.5
 
   text-table@0.2.0: {}
 
@@ -5441,6 +5766,18 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@8.1.0:
+    dependencies:
+      ansi-styles: 6.2.3
+      string-width: 5.1.2
+      strip-ansi: 7.2.0
 
   wrappy@1.0.2: {}
 


### PR DESCRIPTION
Closes #6.

## Design

**Chosen approach:** Thread an optional `requestId` field through `AimlClientOptions` and have each Hono route handler compute the id once at the top (inbound `x-request-id` if present, else `crypto.randomUUID()`), forward it via the client, and echo it on the response.

**Alternative considered:** A Hono middleware that reads/generates the id and writes it to `c.set('rid', ...)`, then read inside each handler. Rejected because:
1. The route file already has explicit per-handler error envelopes that need the id directly, so the indirection of context-vars adds no clarity.
2. A middleware would need to also wrap the AIML client call site, which means either duplicating the forwarding glue or coupling the middleware to client internals.
3. The handlers stay readable: one `const rid = requestId(c);` line at the top of each.

**Tradeoff accepted:** Minor repetition of `requestId(c)` and `c.header('x-request-id', rid)` across 6 handlers. The repetition is local and uniform, so the cost of a future refactor (extract to middleware) is low.

## Implementation

- `aiml.client.ts`: `AimlClientOptions.requestId?: string | null`. `buildHeaders()` sets `x-request-id` when present.
- `rag.routes.ts` + `agent.routes.ts`: `requestId(c)` reads `x-request-id`/`X-Request-Id` (case-tolerant) or generates a fresh v4 UUID. Header is set on every response path including error envelopes; envelopes also include `requestId` in the body.

## Diff layers (one logical step per commit)

1. `feat(api): add requestId to AimlClientOptions, forward as x-request-id` — client surface
2. `feat(api): wire x-request-id through rag + agent routes` — route handlers + error envelopes
3. `test(api): assert x-request-id forwarding + generation behaviour` — initial regression coverage
4. `test(api): expand suite to 100% patch coverage on changed routes` — close the SDLC quality gate

## Quality gates

| Metric | Result |
| --- | --- |
| Tests | **33/33 passing** (was 10) |
| Patch coverage on changed lines | **100%** (rag.routes.ts + agent.routes.ts both 100%; aiml.client.ts 99% — uncovered line is pre-existing) |
| `tsc --noEmit` | clean |
| Lint | clean |
| Conventional commits | yes (4 commits, all conform) |
| Backward compatibility | yes — `requestId` is optional; callers that omit it get a generated id transparently |
| Security | no new attack surface (header is reflective only; AIML service already validates inbound `x-request-id` length-implicitly via UUID parse) |

## AC checklist

- [x] `aiml.client.ts` adds `requestId` to `AimlClientOptions`
- [x] `streamProxy`, `ragQuery`, `ragIngest`, `documentAnalyze`, `agentRun`, `createConversation`, `getConversation` all forward it
- [x] `rag.routes.ts` and `agent.routes.ts` read inbound `x-request-id` (or generate one), pass it down, echo on response
- [x] At least one Vitest case asserts the forwarding (we added 7 covering forward-verbatim, generate-when-missing, error-path echo, multipart, network-fail, etc.)
- [x] No change to existing behavior when caller does not set the header