### PR TITLE
feat(api): probe AIML upstream from /api/health/ready

### DIFF
--- a/apps/api/src/__tests__/routes/health.routes.test.ts
+++ b/apps/api/src/__tests__/routes/health.routes.test.ts
@@ -1,13 +1,26 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { Hono } from "hono";
+import { prisma } from "@repo/database";
 import { healthRoutes } from "../../routes/health.routes.js";
 
 describe("Health Routes", () => {
   let app: Hono;
+  let originalFetch: typeof fetch;
+  let fetchSpy: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    process.env.AIML_SERVICE_URL = "http://aiml.test";
     app = new Hono();
     app.route("/health", healthRoutes);
+    originalFetch = global.fetch;
+    fetchSpy = vi.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.AIML_SERVICE_URL;
+    vi.clearAllMocks();
   });
 
   describe("GET /health", () => {
@@ -35,15 +48,69 @@ describe("Health Routes", () => {
 
   describe("GET /health/ready", () => {
     it("should return ready status with checks", async () => {
+      fetchSpy.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
       const res = await app.request("/health/ready");
       const body = await res.json();
 
-      // Note: This will depend on mocked database response
       expect(res.status).toBe(200);
       expect(body).toHaveProperty("status");
       expect(body).toHaveProperty("checks");
       expect(body.checks).toHaveProperty("database");
       expect(body.checks).toHaveProperty("redis");
+      expect(body.checks).toHaveProperty("aiml");
+    });
+
+    it("reports aiml healthy when upstream /health returns 200", async () => {
+      fetchSpy.mockResolvedValueOnce(new Response("{}", { status: 200 }));
+
+      const res = await app.request("/health/ready");
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.status).toBe("ready");
+      expect(body.checks.aiml.status).toBe("healthy");
+      expect(typeof body.checks.aiml.latency).toBe("number");
+
+      const [calledUrl, init] = fetchSpy.mock.calls[0];
+      expect(calledUrl).toBe("http://aiml.test/health");
+      expect((init as RequestInit).method).toBe("GET");
+    });
+
+    it("reports aiml unhealthy on upstream 5xx but keeps overall ready (DB still healthy)", async () => {
+      fetchSpy.mockResolvedValueOnce(new Response("oops", { status: 503 }));
+
+      const res = await app.request("/health/ready");
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.status).toBe("ready");
+      expect(body.checks.database.status).toBe("healthy");
+      expect(body.checks.aiml.status).toBe("unhealthy");
+    });
+
+    it("reports aiml unhealthy when fetch rejects (network/abort)", async () => {
+      fetchSpy.mockRejectedValueOnce(new Error("ECONNREFUSED"));
+
+      const res = await app.request("/health/ready");
+      const body = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(body.checks.aiml.status).toBe("unhealthy");
+    });
+
+    it("skips the aiml check entirely when DB is unhealthy", async () => {
+      const queryRawMock = prisma.$queryRaw as unknown as ReturnType<typeof vi.fn>;
+      queryRawMock.mockRejectedValueOnce(new Error("db down"));
+
+      const res = await app.request("/health/ready");
+      const body = await res.json();
+
+      expect(res.status).toBe(503);
+      expect(body.status).toBe("not_ready");
+      expect(body.checks.database.status).toBe("unhealthy");
+      expect(body.checks).not.toHaveProperty("aiml");
+      expect(fetchSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/api/src/routes/health.routes.ts
+++ b/apps/api/src/routes/health.routes.ts
@@ -3,6 +3,7 @@ import { Hono } from "hono";
 import { prisma } from "@repo/database";
 import { checkRedisHealth } from "../lib/redis.js";
 import { createServiceLogger } from "../lib/logger.js";
+import { pingAiml } from "../services/aiml.client.js";
 
 const logger = createServiceLogger("health");
 
@@ -47,9 +48,25 @@ const healthRoutes = new Hono()
         status: redisHealthy ? "healthy" : "not_configured",
         latency: redisHealthy ? Date.now() - redisStart : undefined,
       };
+
+      // AIML upstream — informational, does not gate readiness. The API
+      // remains useful (chat, agents-plural, health) even when AIML is
+      // down; surfacing the status here lets operators see degradation
+      // at a glance without taking the whole service offline.
+      const aiml = await pingAiml();
+      if (!aiml.healthy) {
+        logger.warn(
+          { error: aiml.error, latency: aiml.latency },
+          "AIML upstream health check failed",
+        );
+      }
+      checks.aiml = {
+        status: aiml.healthy ? "healthy" : "unhealthy",
+        latency: aiml.latency,
+      };
     }
 
-    // Determine overall status
+    // Determine overall status — AIML is informational, only DB gates readiness.
     const isHealthy = checks.database.status === "healthy";
 
     return c.json(

--- a/apps/api/src/services/aiml.client.ts
+++ b/apps/api/src/services/aiml.client.ts
@@ -102,6 +102,43 @@ async function fetchWithRetry(
   );
 }
 
+/**
+ * Lightweight liveness probe against the AIML service's public `/health`
+ * endpoint. No retry, no auth, short timeout. Never throws — returns a
+ * structured result so callers like the readiness route can decide what
+ * to do with a degraded upstream.
+ */
+export interface AimlHealthResult {
+  healthy: boolean;
+  latency: number;
+  error?: string;
+}
+
+const PING_TIMEOUT_MS = 1500;
+
+export async function pingAiml(opts?: AimlClientOptions): Promise<AimlHealthResult> {
+  const url = `${getBaseUrl(opts)}/health`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), opts?.timeoutMs ?? PING_TIMEOUT_MS);
+  const start = Date.now();
+  try {
+    const resp = await fetch(url, { method: "GET", signal: controller.signal });
+    clearTimeout(timer);
+    const latency = Date.now() - start;
+    if (!resp.ok) {
+      return { healthy: false, latency, error: `upstream returned ${resp.status}` };
+    }
+    return { healthy: true, latency };
+  } catch (err) {
+    clearTimeout(timer);
+    return {
+      healthy: false,
+      latency: Date.now() - start,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+}
+
 export interface RagQueryBody {
   query: string;
   top_k?: number;


### PR DESCRIPTION
## Summary

- Adds `pingAiml` to `aiml.client.ts`: no-retry, no-auth, 1500ms-timeout liveness probe against the AIML service's public `/health` endpoint. Returns `{ healthy, latency, error? }` and never throws.
- Wires the probe into `/api/health/ready` after the existing Postgres + Redis checks. Reports under `checks.aiml`.
- **Informational only** — readiness still gates on the database so AIML being down does not take Railway offline. The chat / agents-plural / health surfaces continue to function without AIML, and operators get an aggregated degradation signal at the readiness endpoint plus a structured warn-level log line with the upstream error and probe latency.
- Skips the probe entirely when the database is unhealthy (matches the existing fail-fast pattern used for the Redis check).

## Why

The recent rag/agent proxy work made AIML a load-bearing downstream for `/api/rag/*` and `/api/agent/*`. If AIML degrades, every proxied request fails — but readiness silently kept reporting 200 because we only check Postgres + Redis. This adds the missing observability without coupling Railway liveness to AIML.

## Test plan

- [x] `pnpm --filter=@repo/api test` — 7/7 health.routes tests pass (3 pre-existing + 4 new: healthy 200, unhealthy 5xx, fetch rejection, DB-down skip). The 5 pre-existing failures (LLM-routing thresholds, chat envelope shape) are unrelated and present on `main`.
- [x] `pnpm --filter=@repo/api exec tsc --noEmit` clean.
- [ ] Hit `GET /api/health/ready` against a stack with the AIML service running — verify `checks.aiml.status === "healthy"` and a sane latency value.
- [ ] Stop the AIML service and re-hit — verify `checks.aiml.status === "unhealthy"`, top-level `status` remains `ready`, response code stays 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)